### PR TITLE
Remove unused comment

### DIFF
--- a/frontend/src/components/EditorCanvas.css
+++ b/frontend/src/components/EditorCanvas.css
@@ -149,7 +149,6 @@ body {
   margin: 0 12px;
 }
 
-/* Generate button */
 .generate-btn {
   background: linear-gradient(135deg, #667eea, #764ba2);
   color: white;


### PR DESCRIPTION
## Summary
- clean up EditorCanvas.css by removing the leftover "Generate button" comment

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6851b2e061588321adc0000519df14bf