### PR TITLE
Switch backend to hosted APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 
 ## Features
-- **Image → Music** via DiffRhythm with timestamped lyrics
+- **Image → Music** via DiffRhythm API and GPT‑4.1‑nano with timestamped lyrics
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
 - REST endpoint `/generate` wraps all pipelines
 - Toggle `TEST_MODE` in `backend/config.py` for offline demos. When enabled, the
-  large Qwen model is not downloaded, which is required on memory-constrained
-  deployments.
+  backend uses bundled mock data and avoids contacting the GPT‑4.1‑nano and
+  DiffRhythm APIs, suitable for memory‑constrained deployments.
 
 ---
 
@@ -46,6 +46,10 @@ omniwizz/
    # Install deps
    pip install -r requirements.txt
    ```
+
+   Set the `OPENAI_API_KEY` and `DIFFRHYTHM_API_KEY` environment variables
+   before running the backend in production mode. You can export them in your
+   shell or place them in a `.env` file that your process reads.
 
 3. **Run the API**
 
@@ -81,8 +85,8 @@ omniwizz/
 
 
 For offline demos or memory-constrained deployments, enable `TEST_MODE` in
-`backend/config.py`. This skips downloading the large vision-language model and
-uses bundled mock data so the API and frontend can run without external
+`backend/config.py`. This skips calling the remote GPT and DiffRhythm services
+and uses bundled mock data so the API and frontend can run without external
 dependencies.
 
 ---

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,1 +1,8 @@
+import os
+
 TEST_MODE = True  # set to False for full production
+
+# API keys for hosted services used when TEST_MODE is disabled
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-nano
+DIFFRHYTHM_API_KEY = os.getenv("DIFFRHYTHM_API_KEY", "")   # DiffRhythm cloud inference
+


### PR DESCRIPTION
## Summary
- use GPT-4.1-nano and DiffRhythm cloud services
- store `OPENAI_API_KEY` and `DIFFRHYTHM_API_KEY` in config
- update LLM processor to call OpenAI API
- replace local DiffRhythm inference with API request
- document API setup in README

## Testing
- `python -m py_compile backend/config.py backend/llm_processors.py backend/diffrhythm_module.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686226535c80832188cd4331b85cc72f