### PR TITLE
Rename DIFFRHYTHM_API_KEY to PIAPI_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
 - REST endpoint `/generate` wraps all pipelines
-- Toggle `TEST_MODE` in `backend/config.py` for offline demos. When enabled, the
-  backend uses bundled mock data and avoids contacting the GPT‑4.1‑nano and
-  DiffRhythm APIs, suitable for memory‑constrained deployments.
+- Toggle `TEST_MODE` (via environment variable or in `backend/config.py`) for offline demos.
+  When enabled, the backend uses bundled mock data and avoids contacting the
+  GPT‑4.1‑nano and DiffRhythm APIs, suitable for memory‑constrained deployments.
 
 ---
 
@@ -47,9 +47,10 @@ omniwizz/
    pip install -r requirements.txt
    ```
 
-   Set the `OPENAI_API_KEY` and `DIFFRHYTHM_API_KEY` environment variables
+   Set the `OPENAI_API_KEY` and `PIAPI_KEY` environment variables
    before running the backend in production mode. You can export them in your
-   shell or place them in a `.env` file that your process reads.
+   shell or place them in a `.env` file that your process reads. Set
+   `TEST_MODE=false` in the environment to enable real API calls.
 
 3. **Run the API**
 
@@ -84,9 +85,10 @@ omniwizz/
 4. Visit `https://<username>.github.io/<repository-name>/` to access OmniWizz.
 
 
-For offline demos or memory-constrained deployments, enable `TEST_MODE` in
-`backend/config.py`. This skips calling the remote GPT and DiffRhythm services
-and uses bundled mock data so the API and frontend can run without external
+For offline demos or memory-constrained deployments, enable `TEST_MODE` either
+in `backend/config.py` or via an environment variable. This skips calling the
+remote GPT and DiffRhythm services and uses bundled mock data so the API and
+frontend can run without external
 dependencies.
 
 ---

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,8 +1,8 @@
 import os
 
-TEST_MODE = True  # set to False for full production
+TEST_MODE = os.getenv("TEST_MODE", "True").lower() == "true"  # set to False for full production
 
 # API keys for hosted services used when TEST_MODE is disabled
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-nano
-DIFFRHYTHM_API_KEY = os.getenv("DIFFRHYTHM_API_KEY", "")   # DiffRhythm cloud inference
+PIAPI_KEY = os.getenv("PIAPI_KEY", "")   # DiffRhythm cloud inference
 

--- a/backend/diffrhythm_module.py
+++ b/backend/diffrhythm_module.py
@@ -2,7 +2,7 @@ import re
 import shutil
 import requests
 from pathlib import Path
-from config import TEST_MODE, DIFFRHYTHM_API_KEY
+from config import TEST_MODE, PIAPI_KEY
 
 def extract_prompt_and_lyrics(output, lang="en"):
     """Return (prompt, lyrics) parsed from raw model output."""
@@ -89,7 +89,7 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     (out_dir / "lyrics.lrc").write_text(lrc, encoding="utf-8")
 
     payload = {"prompt": prompt, "lyrics": lrc}
-    headers = {"Authorization": f"Bearer {DIFFRHYTHM_API_KEY}"}
+    headers = {"Authorization": f"Bearer {PIAPI_KEY}"}
     res = requests.post(
         "https://api.diffrhythm.com/generate",
         json=payload,


### PR DESCRIPTION
## Summary
- rename `DIFFRHYTHM_API_KEY` to `PIAPI_KEY`
- read `TEST_MODE` from env var
- update README usage instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869ca598a2c832188f32389f994fbed