### PR TITLE
Fix missing python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ omniwizz/
    pip install -r requirements.txt
    ```
 
-   Set the `OPENAI_API_KEY` and `PIAPI_KEY` environment variables
-   before running the backend in production mode. You can export them in your
-   shell or place them in a `.env` file that your process reads. Set
-   `TEST_MODE=false` in the environment to enable real API calls. When disabled,
+  Set the `OPENAI_API_KEY` and `PIAPI_KEY` environment variables
+  before running the backend in production mode. The backend uses
+  `python-dotenv` (included in `requirements.txt`) to load variables from a
+  `.env` file if present. Set `TEST_MODE=false` in the environment to enable real API calls. When disabled,
    the backend submits lyrics and prompts to the PiAPI DiffRhythm service via
    `POST https://api.piapi.ai/api/v1/task` and polls `GET /api/v1/task/{task_id}`
    until completion.

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ qwen-vl-utils==0.0.8
 fastapi
 uvicorn
 requests
+python-dotenv


### PR DESCRIPTION
## Summary
- ensure `python-dotenv` is installed by default
- document how environment variables are loaded from `.env`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cd7d9248321b96b0760f7843b94