### PR TITLE
Add configurable CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ omniwizz/
    the backend submits lyrics and prompts to the PiAPI DiffRhythm service via
    `POST https://api.piapi.ai/api/v1/task` and polls `GET /api/v1/task/{task_id}`
    until completion.
+  Optionally set `ALLOW_ORIGINS` (comma separated) to control which domains may
+  access the API when deployed.
 
 3. **Run the API**
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,3 +10,7 @@ print("🚦 TEST_MODE =", TEST_MODE)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-mini
 PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # DiffRhythm cloud inference
 SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")      # SerpAPI for image search
+
+# Domains allowed to call the FastAPI backend. Comma separated. Defaults to
+# the original GitHub Pages deployment location.
+ALLOW_ORIGINS = [o.strip() for o in os.getenv("ALLOW_ORIGINS", "https://jingtianwu.github.io").split(',')]

--- a/backend/server.py
+++ b/backend/server.py
@@ -15,13 +15,14 @@ from diffrhythm_module import run_inference
 
 import os
 from dotenv import load_dotenv
+from config import ALLOW_ORIGINS
 
 load_dotenv()
 
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://jingtianwu.github.io"],  # or ["*"] for testing
+    allow_origins=ALLOW_ORIGINS,  # configure via ALLOW_ORIGINS env var
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=True,


### PR DESCRIPTION
## Summary
- allow `ALLOW_ORIGINS` env var to control CORS
- explain the new variable in README

## Testing
- `python -m py_compile backend/*.py`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a188cb3a083219cbb3f16168a5b47