### PR TITLE
Enable direct audio download via menu

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useMemo, useEffect } from "react";
 import EditorCanvas from "./components/EditorCanvas";
 import VinylIcon from "./components/VinylIcon";
+import { MoreVertical } from "lucide-react";
 import "./index.css";
 
 const BACKEND_URL =
@@ -62,6 +63,7 @@ export default function App() {
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [showAudioMenu, setShowAudioMenu] = useState(false);
 
   /* Pagination */
   const [groupIdx, setGroupIdx] = useState(0);
@@ -368,6 +370,22 @@ export default function App() {
   const lyricsDisabled  = !doMusic || pendingLyrics;
   const regenDisabled   = !doMusic || regenLoading || pendingMusic;
 
+  const handleDownloadAudio = async () => {
+    if (!audioUrl) return;
+    try {
+      const resp = await fetch(audioUrl);
+      const blob = await resp.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "omniwizz_audio";
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Download failed", err);
+    }
+  };
+
   /* RENDER */
   if (stage === "idle") {
     return (
@@ -644,9 +662,29 @@ export default function App() {
                     playing ? audioRef.current.pause() : audioRef.current.play();
                   }}
                 />
+                <button
+                  className="vinyl-menu-btn"
+                  onClick={() => setShowAudioMenu(prev => !prev)}
+                >
+                  <MoreVertical size={18} />
+                </button>
+                {showAudioMenu && (
+                  <div
+                    className="vinyl-menu"
+                    tabIndex={-1}
+                    onBlur={() => setShowAudioMenu(false)}
+                  >
+                    <button
+                      className="vinyl-menu-item"
+                      onClick={() => { handleDownloadAudio(); setShowAudioMenu(false); }}
+                    >
+                      Download Audio
+                    </button>
+                  </div>
+                )}
                 {duration > 0 && (
                   <div className="vinyl-time-display">
-                    {Math.floor(currentTime / 60)}:{(Math.floor(currentTime % 60)).toString().padStart(2, '0')} / 
+                    {Math.floor(currentTime / 60)}:{(Math.floor(currentTime % 60)).toString().padStart(2, '0')} /
                     {Math.floor(duration / 60)}:{(Math.floor(duration % 60)).toString().padStart(2, '0')}
                   </div>
                 )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1009,3 +1009,42 @@ html { scroll-behavior: smooth; }
   transform-box: fill-box;
   transform-origin: center;
 }
+
+/* Menu button for vinyl options */
+.vinyl-menu-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  z-index: 7;
+}
+
+/* Options dropdown */
+.vinyl-menu {
+  position: absolute;
+  top: 36px;
+  right: 6px;
+  background: rgba(30, 30, 40, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 6px 0;
+  min-width: 120px;
+  z-index: 50;
+}
+
+.vinyl-menu-item {
+  display: block;
+  width: 100%;
+  padding: 6px 12px;
+  text-align: left;
+  color: #ddd;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.vinyl-menu-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}


### PR DESCRIPTION
## Summary
- add `lucide-react` vertical menu button in the vinyl player
- implement audio download with blob URL
- add dropdown styles for menu

## Testing
- `npm test --silent` *(fails: npm attempted to access network)*

------
https://chatgpt.com/codex/tasks/task_e_686ca16267648321a2fa8f5b22052237