### PR TITLE
Clean up dynamic inline styles

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -320,6 +320,22 @@ export default function App() {
   }, [visibleImages]);
 
   useEffect(() => {
+    document.querySelectorAll('.cloud-img').forEach((img, i) => {
+      if (imagePositions[i]) {
+        img.style.setProperty('--x', imagePositions[i].x);
+        img.style.setProperty('--y', imagePositions[i].y);
+        img.style.setProperty('--rotation', `${imagePositions[i].rotation}deg`);
+      }
+    });
+    document.querySelectorAll('.cloud-tag').forEach((tag, i) => {
+      if (tagPositions[i]) {
+        tag.style.setProperty('--x', tagPositions[i].x);
+        tag.style.setProperty('--y', tagPositions[i].y);
+      }
+    });
+  }, [imagePositions, tagPositions]);
+
+  useEffect(() => {
     if (!pendingMusic || !audioUrl) return;
     const id = setInterval(async () => {
       try {
@@ -627,8 +643,7 @@ export default function App() {
                     strokeWidth="2"
                     style={{
                       transition: 'cx 0.1s linear, cy 0.1s linear',
-                      filter: 'drop-shadow(0 0 6px rgba(0,255,209,0.6))',
-                      pointerEvents: 'none'
+                      filter: 'drop-shadow(0 0 6px rgba(0,255,209,0.6))'
                     }}
                   />
                   <defs>
@@ -713,13 +728,9 @@ export default function App() {
                   alt=""
                   className="cloud-img"
                   draggable={false}
-                  style={{
-                    left: `${x}%`,
-                    top: `${y}%`,
-                    "--r": `${rotation}deg`,
-                    userSelect: "none",
-                    WebkitUserDrag: "none"
-                  }}
+                  data-x={x}
+                  data-y={y}
+                  data-rotation={rotation}
                 />
               ))}
             </div>
@@ -732,11 +743,8 @@ export default function App() {
                   key={i}
                   className="cloud-tag"
                   draggable={false}
-                  style={{
-                    left: `${x}%`, 
-                    top: `${y}%`,
-                    userSelect: "none"
-                  }}
+                  data-x={x}
+                  data-y={y}
                 >
                   {visibleTags[i]}
                 </span>

--- a/frontend/src/components/EditorCanvas.jsx
+++ b/frontend/src/components/EditorCanvas.jsx
@@ -198,6 +198,23 @@ const EditorCanvas = forwardRef(function EditorCanvas({ onSubmit, language, setL
                  document.removeEventListener("mouseup",   up); };
   }, []);
 
+  useEffect(() => {
+    boxes.forEach(b => {
+      const el = document.getElementById(`tb-${b.id}`);
+      if (el) {
+        el.style.setProperty('--font-size', b.fs);
+        el.style.setProperty('--color', b.color);
+        if (b.width != null) el.style.setProperty('--width', `${b.width}px`);
+        if (b.height != null) el.style.setProperty('--height', `${b.height}px`);
+        const parent = el.parentElement;
+        if (parent) {
+          parent.style.setProperty('--x', b.x);
+          parent.style.setProperty('--y', b.y);
+        }
+      }
+    });
+  }, [boxes]);
+
   /* -------------- Drop image on artboard -------------- */
   const onBgDrop = e => {
     e.preventDefault();
@@ -627,10 +644,7 @@ const handleFontSizeChange = (boxId, newSize) => {
             ref={inkRef}
             width={W}
             height={H}
-            style={{
-              position: 'absolute',
-              cursor: mode === "pen" ? "crosshair" : mode === "erase" ? "cell" : mode === "text" ? "crosshair" : "default"
-            }}
+            className={`ink-canvas cursor-${mode}`}
             onMouseDown={startStroke}
             onMouseMove={drawMove}
             onMouseUp={endStroke}
@@ -640,7 +654,7 @@ const handleFontSizeChange = (boxId, newSize) => {
           />
           
           {!bgSrc && showHint && (
-            <div className="drop-zone" style={{ pointerEvents: 'none' }}>
+            <div className="drop-zone">
               <div className="drop-text">
                 Draw or do anything you like!
                 <br />
@@ -655,12 +669,9 @@ const handleFontSizeChange = (boxId, newSize) => {
             return (
               <div
                 key={b.id}
-                style={{
-                  position: "absolute",
-                  left: b.x,
-                  top: b.y,
-                  pointerEvents: mode === "pen" || mode === "erase" ? "none" : "auto"
-                }}
+                className={`textbox-container ${mode === "pen" || mode === "erase" ? "no-pointer" : ""}`}
+                data-x={b.x}
+                data-y={b.y}
                 onMouseDown={(ev) => {
                   if (b.editing || mode !== "move") return;
                   const pr = contRef.current.getBoundingClientRect();
@@ -772,23 +783,13 @@ const handleFontSizeChange = (boxId, newSize) => {
 
                 <div
                   id={`tb-${b.id}`}
-                  className={`textbox ${sel ? "active" : ""} ${b.editing ? "editing" : ""}`}
+                  className={`textbox ${sel ? "active" : ""} ${b.editing ? "editing" : ""} ${mode === "pen" || mode === "erase" ? "no-pointer" : ""}`}
                   contentEditable={b.editing}
                   suppressContentEditableWarning
-                  style={{
-                    fontSize: b.fs,
-                    color: b.color,
-                    width: b.width != null ? `${b.width}px` : "auto",
-                    height: b.height != null ? `${b.height}px` : "auto",
-                    boxSizing: "border-box",
-                    overflow: "hidden",
-                    whiteSpace: "pre-wrap",
-                    wordWrap: "break-word",
-                    overflowWrap: "break-word",
-                    cursor: b.editing ? 'text' : 'pointer',
-                    userSelect: b.editing ? 'text' : 'none',
-                    pointerEvents: mode === "pen" || mode === "erase" ? "none" : "auto"
-                  }}
+                  data-font-size={b.fs}
+                  data-color={b.color}
+                  data-width={b.width}
+                  data-height={b.height}
                   onClick={(e) => {
                     e.stopPropagation();
                     if (mode === "move" && !sel) setSel(b.id);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -308,18 +308,22 @@ html { scroll-behavior: smooth; }
 
 .cloud-img {
   position: absolute;
+  left: calc(var(--x, 50) * 1%);
+  top: calc(var(--y, 50) * 1%);
   width: 120px; height: 120px;
   object-fit: contain;
   border-radius: 20px;
   box-shadow: 0 12px 32px rgba(0,0,0,0.4);
   animation: float 7s ease-in-out infinite;
-  transform: translate(-50%,-50%) rotate(var(--r));
+  transform: translate(-50%,-50%) rotate(var(--rotation, 0deg));
   border: 2px solid rgba(255,255,255,0.2);
   transition: all 0.4s cubic-bezier(0.4,0,0.2,1);
   cursor: pointer;
   z-index: 1;
   background: rgba(255,255,255,0.1);
   backdrop-filter: blur(5px);
+  user-select: none;
+  -webkit-user-drag: none;
 }
 .cloud-img:hover {
   transform: translate(-50%,-50%) rotate(0deg) scale(2.5);
@@ -332,14 +336,16 @@ html { scroll-behavior: smooth; }
   width: 240px; height: 240px;
 }
 @keyframes float {
-  0%,100% { transform: translate(-50%,-50%) translateY(-8px) rotate(var(--r)); }
-  50%    { transform: translate(-50%,-50%) translateY(12px) rotate(var(--r)); }
+  0%,100% { transform: translate(-50%,-50%) translateY(-8px) rotate(var(--rotation, 0deg)); }
+  50%    { transform: translate(-50%,-50%) translateY(12px) rotate(var(--rotation, 0deg)); }
 }
 
 /* FLOATING TAG CLOUD */
 .tag-cloud { position: absolute; inset: 0; pointer-events: none; }
 .cloud-tag {
   position: absolute;
+  left: calc(var(--x, 50) * 1%);
+  top: calc(var(--y, 50) * 1%);
   transform: translate(-50%,-50%);
   background: linear-gradient(135deg, rgba(255,255,255,.95), rgba(255,255,255,.85));
   color: #222;
@@ -1067,4 +1073,30 @@ html { scroll-behavior: smooth; }
 .vinyl-menu-item:hover {
   background: rgba(255, 255, 255, 0.1);
   color: #fff;
+}
+
+/* Canvas cursors */
+.ink-canvas {
+  position: absolute;
+}
+.cursor-pen { cursor: crosshair; }
+.cursor-erase { cursor: cell; }
+.cursor-text { cursor: crosshair; }
+.cursor-move { cursor: default; }
+
+/* Pointer events */
+.no-pointer { pointer-events: none; }
+
+/* Dynamic positioning */
+.textbox-container {
+  position: absolute;
+  left: calc(var(--x, 0) * 1px);
+  top: calc(var(--y, 0) * 1px);
+}
+
+.textbox[data-font-size] {
+  font-size: calc(var(--font-size, 24) * 1px);
+  color: var(--color);
+  width: var(--width, auto);
+  height: var(--height, auto);
 }


### PR DESCRIPTION
## Summary
- move textbox positioning/size logic to CSS variables
- adjust cloud image and tag layout using data attributes
- add canvas cursor classes and no-pointer utility
- set CSS variables through useEffect hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb9ef1a5c8321b53e79b6221f23f5