### PR TITLE
Switch to Google scraping for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Features
 - **Image → Music** via DiffRhythm API and GPT‑4.1‑nano with timestamped lyrics
 - **Image → Tags** for creativity prompts
-- **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
+- **Image → Related Images** via Google scraping (no API key required)
 - REST endpoint `/generate` wraps all pipelines
 - Toggle `TEST_MODE` (via environment variable or in `backend/config.py`) for offline demos.
   When enabled, the backend uses bundled mock data and avoids contacting the

--- a/backend/google_scrape_module.py
+++ b/backend/google_scrape_module.py
@@ -1,0 +1,44 @@
+import requests, io
+from pathlib import Path
+from PIL import Image
+from bs4 import BeautifulSoup
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0 Safari/537.36"
+}
+
+ALLOWED_FORMATS = {"jpg", "jpeg", "png", "gif"}
+
+
+def fetch_images_for_entity(entity: str, num: int = 1, out_dir: Path = None):
+    """Scrape Google Images for `entity` and download top `num` images."""
+    out_dir = out_dir or Path.cwd()
+    query = entity.replace(" ", "+")
+    url = f"https://www.google.com/search?tbm=isch&q={query}"
+    res = requests.get(url, headers=HEADERS, timeout=10)
+    soup = BeautifulSoup(res.text, "html.parser")
+
+    paths = []
+    for img in soup.select("img"):
+        img_url = img.get("data-iurl") or img.get("src")
+        if not img_url or img_url.startswith("data:"):
+            continue
+
+        ext = img_url.split(".")[-1].split("?")[0].lower()
+        if ext not in ALLOWED_FORMATS:
+            continue
+
+        try:
+            img_data = requests.get(img_url, headers=HEADERS, timeout=10).content
+            Image.open(io.BytesIO(img_data)).verify()
+            fname = f"{entity.replace(' ', '_')}_{len(paths)}.{ext}"
+            local = out_dir / fname
+            local.write_bytes(img_data)
+            paths.append(str(local))
+        except Exception:
+            continue
+
+        if len(paths) >= num:
+            break
+
+    return paths

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,7 +12,7 @@ from llm_processors import (
     ImageToVisualEntitiesProcessor,
 )
 from udio_module import run_inference
-from serpapi_module import fetch_images_for_entity
+from google_scrape_module import fetch_images_for_entity
 
 OUTPUT_ROOT = Path(__file__).parent.parent / "output"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ uvicorn
 requests
 python-multipart
 python-dotenv
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ fastapi
 uvicorn
 requests
 python-dotenv
+beautifulsoup4


### PR DESCRIPTION
## Summary
- scrape Google Images instead of SerpAPI
- import new scraper in the pipeline
- document the change
- add BeautifulSoup dependency

## Testing
- `python3 -m py_compile backend/google_scrape_module.py backend/pipeline.py backend/serpapi_module.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6870073235748321a160e1f3f1e06309