### PR TITLE
Fix audio reuse and trimming

### DIFF
--- a/frontend/src/components/EditorCanvas.jsx
+++ b/frontend/src/components/EditorCanvas.jsx
@@ -88,7 +88,8 @@ const EditorCanvas = forwardRef(function EditorCanvas({ onSubmit, language, setL
       bg: bgSrc,
       boxes,
       hasWave,
-      audio: hasWave ? audRef.current.toDataURL("image/png") : null
+      audio: hasWave ? audRef.current.toDataURL("image/png") : null,
+      audioFile: audioFileRef.current
     }),
     getAudioFile: () => audioFileRef.current,
     loadSnapshot: snap => {
@@ -116,9 +117,13 @@ const EditorCanvas = forwardRef(function EditorCanvas({ onSubmit, language, setL
         im.onload = () => { audCtx().drawImage(im, 0, 0); };
         im.src = snap.audio;
         setWave(true);
+        if (snap.audioFile) {
+          audioFileRef.current = snap.audioFile;
+        }
       } else {
         audCtx().clearRect(0, 0, W, AUDIO_H);
         setWave(false);
+        audioFileRef.current = null;
       }
     },
     dismissHint: () => setShowHint(false),


### PR DESCRIPTION
## Summary
- persist audio file within canvas snapshots so re-edits resend audio
- limit uploaded audio to first 30s for chord transcription

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `python -m py_compile backend/musicai_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68733220d77c83218769ad99a5f03b06