### PR TITLE
Improve logging clarity

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -220,7 +220,26 @@ async def fetch(folder: str, subpath: str, request: Request, db: DBSession = Dep
     else:
         media_type = "application/octet-stream"
 
-    log_event(db, request.state.session_id, "fetch_output", path=f"{folder}/{subpath}")
+    asset_type = "other"
+    sp_lower = subpath.lower()
+    if sp_lower == "tags.json":
+        asset_type = "tags"
+    elif sp_lower.startswith("images/"):
+        asset_type = "image"
+    elif sp_lower.endswith("prompt.txt"):
+        asset_type = "prompt"
+    elif sp_lower.endswith("lyrics.lrc"):
+        asset_type = "lyrics"
+    elif sp_lower.endswith(".wav"):
+        asset_type = "audio"
+
+    log_event(
+        db,
+        request.state.session_id,
+        "fetch_output",
+        path=f"{folder}/{subpath}",
+        asset_type=asset_type,
+    )
     return FileResponse(str(fp), media_type=media_type)
 
 


### PR DESCRIPTION
## Summary
- log when prompt and lyric text areas are modified or reset
- rename audio seek event to `audio_seek_click`
- keep track of original prompt/lyrics for comparison

## Testing
- `python -m py_compile backend/server.py`


------
https://chatgpt.com/codex/tasks/task_e_687ac4faed74832181703f3a10d37b6a