### PR TITLE
feat: add instrumental option

### DIFF
--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -31,6 +31,7 @@ def generate_music_from_image(
     language: str = "en",
     run_dir: Path = None,
     audio_path: str | None = None,
+    instrumental: bool = False,
 ) -> str:
     # 1) Prepare run_dir
     out_dir = run_dir or _make_run_dir()
@@ -74,10 +75,15 @@ def generate_music_from_image(
 
     # 5) Inference (or mock)
     try:
-        audio_path = run_inference(assistant_reply, out_dir)
+        audio_path = run_inference(assistant_reply, out_dir, instrumental=instrumental)
     except Exception as e:
         print(f"Udio failed: {e}; using mock audio")
-        audio_path = run_inference(assistant_reply, out_dir, use_mock=True)
+        audio_path = run_inference(
+            assistant_reply,
+            out_dir,
+            use_mock=True,
+            instrumental=instrumental,
+        )
     return audio_path
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -84,6 +84,7 @@ async def generate(
     request: Request,
     file: UploadFile = File(...),
     audio: UploadFile | None = File(None),
+    instrumental: bool = Form(False),
     language: str = "en",
     modes: str = "music,tags,images",  # default all three
     db: DBSession = Depends(get_session),
@@ -141,6 +142,7 @@ async def generate(
                 language,
                 run_dir,
                 str(audio_path) if audio_path else None,
+                instrumental,
             )
             results["music"] = {
                 "folder": folder,
@@ -173,6 +175,7 @@ async def regenerate(
     folder: str = Form(...),
     prompt: str = Form(...),
     lyrics: str = Form(...),
+    instrumental: bool = Form(False),
     db: DBSession = Depends(get_session),
 ):
     out_dir = OUTPUT_DIR / folder
@@ -190,7 +193,9 @@ async def regenerate(
         lrc_fp.unlink()
     
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
-    background_tasks.add_task(run_inference, assistant_reply, out_dir)
+    background_tasks.add_task(
+        run_inference, assistant_reply, out_dir, instrumental=instrumental
+    )
 
     log_event(
         db,

--- a/backend/udio_module.py
+++ b/backend/udio_module.py
@@ -56,9 +56,17 @@ def extract_prompt_and_lyrics(output, lang="en"):
     return prompt, lyrics
 
 
-def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_MODE) -> str:
-    """
-    Generate music using the Udio model via PiAPI.
+def run_inference(
+    assistant_reply: str,
+    out_dir: Path,
+    *,
+    use_mock: bool = TEST_MODE,
+    instrumental: bool = False,
+) -> str:
+    """Generate music using the Udio model via PiAPI.
+
+    When ``instrumental`` is True, the request is sent with
+    ``lyrics_type='instrumental'`` and no lyrics are included in the payload.
 
     Writes ``lyrics.lrc`` (plain text) and ``audio.wav`` into ``out_dir`` and
     returns the path to the audio file.
@@ -66,6 +74,8 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     if use_mock:
         # ==== MOCK MODE ====
         prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
+        if instrumental:
+            lyrics = ""
         (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
 
         mock_wav_path = Path(__file__).parent / "mock_data" / "mock_audio.wav"
@@ -75,16 +85,21 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
 
     # ==== REAL MODE ====
     prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
+    if instrumental:
+        lyrics = ""
     (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+
+    payload_input = {
+        "prompt": prompt,
+        "lyrics_type": "instrumental" if instrumental else "user",
+    }
+    if not instrumental:
+        payload_input["lyrics"] = lyrics
 
     payload = {
         "model": "music-u",
         "task_type": "generate_music",
-        "input": {
-            "prompt": prompt,
-            "lyrics_type": "user",
-            "lyrics": lyrics,
-        },
+        "input": payload_input,
         "config": {},
     }
     headers = {"X-API-Key": PIAPI_KEY}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,6 +46,7 @@ export default function App() {
   const [doTags, setDoTags]     = useState(true);
   const [doMusic, setDoMusic]   = useState(true);
   const [doImages, setDoImages] = useState(true);
+  const [instrumental, setInstrumental] = useState(false);
 
   /* Language */
   const [language, setLanguage] = useState("en");
@@ -172,6 +173,7 @@ export default function App() {
     const v = e.target.checked;
     if (!v && !doTags && !doImages) return;
     setDoMusic(v);
+    if (!v) setInstrumental(false);
     log("toggle_music", { value: v });
   };
   const onImagesToggle = e => {
@@ -179,6 +181,11 @@ export default function App() {
     if (!v && !doTags && !doMusic) return;
     setDoImages(v);
     log("toggle_images", { value: v });
+  };
+  const onInstrumentalToggle = e => {
+    const v = e.target.checked;
+    setInstrumental(v);
+    log("toggle_instrumental", { value: v });
   };
 
   /* File upload + generate */
@@ -209,6 +216,7 @@ export default function App() {
     const data = new FormData();
     data.append("file", file);
     if (audioFile) data.append("audio", audioFile);
+    data.append("instrumental", instrumental ? "1" : "0");
     const modes = [doMusic && "music", doTags && "tags", doImages && "images"]
       .filter(Boolean)
       .join(",");
@@ -230,12 +238,9 @@ export default function App() {
         setPendingMusic(!!j.music.pending);
         setRunFolder(j.music.folder || "");
         setPendingPrompt(true);
-        setPendingLyrics(true);
+        setPendingLyrics(!instrumental);
         try {
-          const [prResp, lyrResp] = await Promise.all([
-            fetch(withBase(j.music.prompt_url)),
-            fetch(withBase(j.music.lyrics_url))
-          ]);
+          const prResp = await fetch(withBase(j.music.prompt_url));
           if (prResp.ok) {
             const txt = await prResp.text();
             origPromptRef.current = txt;
@@ -243,12 +248,15 @@ export default function App() {
             setPromptText(txt);
             setPendingPrompt(false);
           }
-          if (lyrResp.ok) {
-            const lyr = await lyrResp.text();
-            origLyricsRef.current = lyr;
-            lyricsModifiedRef.current = false;
-            setLyricsText(lyr);
-            setPendingLyrics(false);
+          if (!instrumental) {
+            const lyrResp = await fetch(withBase(j.music.lyrics_url));
+            if (lyrResp.ok) {
+              const lyr = await lyrResp.text();
+              origLyricsRef.current = lyr;
+              lyricsModifiedRef.current = false;
+              setLyricsText(lyr);
+              setPendingLyrics(false);
+            }
           }
         } catch {}
       }
@@ -315,7 +323,8 @@ export default function App() {
       const data = new FormData();
       data.append("folder", runFolder);
       data.append("prompt", promptText);
-      data.append("lyrics", lyricsText);
+      data.append("lyrics", instrumental ? "" : lyricsText);
+      data.append("instrumental", instrumental ? "1" : "0");
       const res = await fetch(`${BACKEND_URL}/regenerate`, { method: "POST", body: data });
       const j = await res.json();
       if (j.audio_url) {
@@ -450,7 +459,7 @@ export default function App() {
   const cx       = 100 + R * Math.cos(theta);
   const cy       = 100 + R * Math.sin(theta);
   const promptDisabled  = !doMusic || pendingPrompt;
-  const lyricsDisabled  = !doMusic || pendingLyrics;
+  const lyricsDisabled  = instrumental || !doMusic || pendingLyrics;
   const regenDisabled   = !doMusic || regenLoading || pendingMusic;
 
   const handleDownloadAudio = async () => {
@@ -630,6 +639,15 @@ export default function App() {
               <span>Music</span>
             </label>
             <label className="option-toggle">
+              <input
+                type="checkbox"
+                checked={instrumental}
+                onChange={onInstrumentalToggle}
+                disabled={!doMusic}
+              />
+              <span>Instrumental</span>
+            </label>
+            <label className="option-toggle">
               <input type="checkbox" checked={doImages} onChange={onImagesToggle} />
               <span>Images</span>
             </label>
@@ -668,6 +686,16 @@ export default function App() {
           </div>
         )}
         <div className="prompt-box">
+          <button
+            className={`instrumental-btn ${instrumental ? "active" : ""}`}
+            onClick={() => {
+              const v = !instrumental;
+              setInstrumental(v);
+              log("toggle_instrumental", { value: v });
+            }}
+          >
+            {instrumental ? "Instrumental On" : "Instrumental Off"}
+          </button>
           <label className="prompt-field">
             <div className="prompt-label">Prompt</div>
             <textarea
@@ -715,9 +743,11 @@ export default function App() {
               placeholder={
                 !doMusic
                   ? "Music option not selected..."
-                  : pendingLyrics
-                    ? "Loading lyrics..."
-                    : "Enter lyrics (optional)"
+                  : instrumental
+                    ? "Instrumental mode: no lyrics"
+                    : pendingLyrics
+                      ? "Loading lyrics..."
+                      : "Enter lyrics (optional)"
               }
               disabled={lyricsDisabled}
               className="prompt-input lyrics-textarea"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -826,6 +826,26 @@ html { scroll-behavior: smooth; }
   opacity: 0.7;
 }
 
+/* Instrumental toggle button */
+.instrumental-btn {
+  align-self: flex-end;
+  margin-bottom: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: white;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.instrumental-btn.active {
+  background: rgba(255,255,255,0.25);
+}
+.instrumental-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Generate button */
 .prompt-box .generate-btn {
   background: linear-gradient(135deg, #667eea, #764ba2, #f093fb);


### PR DESCRIPTION
## Summary
- allow toggling instrumental mode through API and UI
- disable lyrics editing when instrumental is active and send proper flag to backend
- style new instrumental button

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b200cf96c4832183f9418509ccc098