### PR TITLE
feat: add MusicGPT fallback for audio generation

### DIFF
--- a/backend/audio_generation.py
+++ b/backend/audio_generation.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from musicgpt_module import run_inference as run_musicgpt
+from udio_module import run_inference as run_udio
+
+
+def generate_audio(assistant_reply: str, out_dir: Path) -> str:
+    """Generate audio using MusicGPT with fallbacks to Udio and mock output."""
+    try:
+        return run_musicgpt(assistant_reply, out_dir)
+    except Exception as e:
+        print(f"MusicGPT failed: {e}; falling back to Udio")
+        try:
+            return run_udio(assistant_reply, out_dir)
+        except Exception as e2:
+            print(f"Udio failed: {e2}; using mock audio")
+            return run_udio(assistant_reply, out_dir, use_mock=True)

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,3 +12,4 @@ PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Udio cloud inference
 SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")      # SerpAPI for image search
 MUSIC_AI_API_KEY = os.getenv("MUSIC_AI_API_KEY", "")    # Music AI chord transcription
 MUSICAI_CHORD_WORKFLOW = os.getenv("MUSICAI_CHORD_WORKFLOW", "untitled-workflow-1fe2713")
+MUSICGPT_API_KEY = os.getenv("MUSICGPT_API_KEY", "")     # MusicGPT generation

--- a/backend/musicgpt_module.py
+++ b/backend/musicgpt_module.py
@@ -1,0 +1,61 @@
+import time
+import requests
+from pathlib import Path
+from config import TEST_MODE, MUSICGPT_API_KEY
+from udio_module import extract_prompt_and_lyrics
+
+API_BASE = "https://api.musicgpt.com/api/public/v1"
+
+
+def run_inference(assistant_reply: str, out_dir: Path) -> str:
+    """Generate music using the MusicGPT API.
+
+    Writes ``lyrics.lrc`` and ``audio.wav`` into ``out_dir`` and returns the
+    path to the audio file.
+    """
+    if TEST_MODE or not MUSICGPT_API_KEY:
+        raise RuntimeError("MusicGPT disabled in test mode or missing API key")
+
+    prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
+    (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+
+    headers = {
+        "Authorization": MUSICGPT_API_KEY,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "prompt": prompt,
+        "lyrics": lyrics,
+        "music_style": "",
+        "make_instrumental": False,
+        "vocal_only": False,
+        "voice_id": "",
+        "webhook_url": "",
+    }
+
+    res = requests.post(f"{API_BASE}/MusicAI", json=payload, headers=headers, timeout=120)
+    res.raise_for_status()
+    data = res.json()
+
+    conv_ids = [data.get("conversion_id_1"), data.get("conversion_id_2")]
+    conv_ids = [cid for cid in conv_ids if cid]
+    if not conv_ids:
+        raise RuntimeError("No conversion id returned from MusicGPT API")
+
+    for conv_id in conv_ids:
+        for _ in range(60):
+            poll = requests.get(f"{API_BASE}/conversion/{conv_id}", headers=headers, timeout=120)
+            if poll.status_code == 200:
+                j = poll.json()
+                audio_url = j.get("conversion_path_wav") or j.get("conversion_path")
+                status = j.get("status")
+                if audio_url:
+                    wav_res = requests.get(audio_url, timeout=120)
+                    wav_res.raise_for_status()
+                    audio_path = out_dir / "audio.wav"
+                    audio_path.write_bytes(wav_res.content)
+                    return str(audio_path)
+                if status in {"failed", "error"}:
+                    break
+            time.sleep(5)
+    raise RuntimeError("MusicGPT API timed out")

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,7 +12,7 @@ from llm_processors import (
     ImageToTagsProcessor,
     ImageToVisualEntitiesProcessor,
 )
-from udio_module import run_inference
+from audio_generation import generate_audio
 from serpapi_module import fetch_images_for_entity
 
 OUTPUT_ROOT = Path(__file__).parent.parent / "output"
@@ -69,15 +69,11 @@ def generate_music_from_image(
     with open(out_dir / "prompt.txt", "w", encoding="utf-8") as f:
         f.write(prompt)
 
-    # 4) Assemble assistant reply for Udio
+    # 4) Assemble assistant reply for music generation
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
 
-    # 5) Inference (or mock)
-    try:
-        audio_path = run_inference(assistant_reply, out_dir)
-    except Exception as e:
-        print(f"Udio failed: {e}; using mock audio")
-        audio_path = run_inference(assistant_reply, out_dir, use_mock=True)
+    # 5) Inference with fallback chain
+    audio_path = generate_audio(assistant_reply, out_dir)
     return audio_path
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -24,7 +24,7 @@ from pipeline import (
     generate_tags_from_image,
     generate_images_from_image,
 )
-from udio_module import run_inference
+from audio_generation import generate_audio
 
 import os
 from dotenv import load_dotenv
@@ -190,7 +190,7 @@ async def regenerate(
         lrc_fp.unlink()
     
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
-    background_tasks.add_task(run_inference, assistant_reply, out_dir)
+    background_tasks.add_task(generate_audio, assistant_reply, out_dir)
 
     log_event(
         db,


### PR DESCRIPTION
## Summary
- integrate MusicGPT API and polling logic
- add wrapper that falls back to Udio or mock audio
- wire pipeline and server to new audio generation flow
- configure MUSICGPT_API_KEY

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b25ac4324c8321a35293b62f6b825e