### PR TITLE
Replace Udio with MusicGPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ## Features
-- **Image → Music** via Udio (PiAPI) and GPT-4.1-mini lyrics
+- **Image → Music** via MusicGPT and GPT-4.1-mini lyrics
 - **Optional audio upload analyzed with Music AI for key & chord progression**
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
@@ -14,7 +14,7 @@
 - `/regenerate` re-runs music synthesis with your own prompt and lyrics
 - Toggle `TEST_MODE` (via environment variable or in `backend/config.py`) for offline demos.
   When enabled, the backend uses bundled mock data and avoids contacting the
-  GPT-4.1-mini and Udio (PiAPI) services, suitable for memory-constrained deployments.
+  GPT-4.1-mini and MusicGPT services, suitable for memory-constrained deployments.
 
 ---
 
@@ -26,7 +26,7 @@ omniwizz/
 │   ├── llm_module.py        ← optional Qwen2.5-VL helper
 │   ├── llm_processors.py    ← OpenAI-based processors
 │   ├── serpapi_module.py    ← related image search via SerpAPI
-│   ├── udio_module.py       ← generate music with Udio
+│   ├── musicgpt_module.py   ← generate music with MusicGPT
 │   ├── pipeline.py          ← core logic: routes inputs through modules
 │   └── server.py            ← FastAPI endpoints (`/generate`, `/regenerate`)
 │
@@ -49,14 +49,14 @@ omniwizz/
    pip install -r requirements.txt
    ```
 
-  Set the `OPENAI_API_KEY`, `PIAPI_KEY`, `SERPAPI_API_KEY`, and `MUSIC_AI_API_KEY` environment variables
+  Set the `OPENAI_API_KEY`, `MUSICGPT_API_KEY`, `SERPAPI_API_KEY`, and `MUSIC_AI_API_KEY` environment variables
   before running the backend in production mode. The chord transcription workflow can be
   configured via the optional `MUSICAI_CHORD_WORKFLOW` variable.
   The backend uses
   `python-dotenv` (included in `requirements.txt`) to load variables from a
   `.env` file if present. Set `TEST_MODE=false` in the environment to enable real API calls. When disabled,
-   the backend submits lyrics and prompts to the PiAPI Udio service via
-   `POST https://api.piapi.ai/api/v1/task` and polls `GET /api/v1/task/{task_id}`
+   the backend submits lyrics and prompts to the MusicGPT service via
+   `POST https://api.musicgpt.com/api/public/v1/MusicAI` and polls `GET /conversion/{id}`
    until completion.
 
 3. **Run the API**
@@ -92,7 +92,7 @@ omniwizz/
 4. Visit `https://<username>.github.io/<repository-name>/` to access OmniWizz.
 
 
-For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and Udio (PiAPI) services so the API and frontend can run without external dependencies.
+For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and MusicGPT services so the API and frontend can run without external dependencies.
 
 ---
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,7 @@ print("🚦 TEST_MODE =", TEST_MODE)
 
 # API keys for hosted services used when TEST_MODE is disabled
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-mini
-PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Udio cloud inference
+MUSICGPT_API_KEY = os.getenv("MUSICGPT_API_KEY", "")    # MusicGPT music generation
 SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")      # SerpAPI for image search
 MUSIC_AI_API_KEY = os.getenv("MUSIC_AI_API_KEY", "")    # Music AI chord transcription
 MUSICAI_CHORD_WORKFLOW = os.getenv("MUSICAI_CHORD_WORKFLOW", "untitled-workflow-1fe2713")

--- a/backend/llm_processors.py
+++ b/backend/llm_processors.py
@@ -1,7 +1,7 @@
 import requests
 import re
 import ast
-from udio_module import extract_prompt_and_lyrics
+from musicgpt_module import extract_prompt_and_lyrics
 from config import TEST_MODE, OPENAI_API_KEY
 import base64
 import mimetypes

--- a/backend/musicgpt_module.py
+++ b/backend/musicgpt_module.py
@@ -1,9 +1,14 @@
 import re
 import shutil
 import time
-import requests
 from pathlib import Path
-from config import TEST_MODE, PIAPI_KEY
+
+import requests
+
+from config import TEST_MODE, MUSICGPT_API_KEY
+
+API_BASE = "https://api.musicgpt.com/api/public/v1"
+
 
 def extract_prompt_and_lyrics(output, lang="en"):
     """Return (prompt, lyrics) parsed from raw model output."""
@@ -36,7 +41,7 @@ def extract_prompt_and_lyrics(output, lang="en"):
     for pat in p_pats:
         m = re.search(pat, output, re.IGNORECASE | re.DOTALL)
         if m:
-            prompt = re.sub(r'\*{1,3}', '', m.group(1)).strip()
+            prompt = re.sub(r"\*{1,3}", "", m.group(1)).strip()
             break
 
     # Try to extract the lyrics
@@ -51,14 +56,13 @@ def extract_prompt_and_lyrics(output, lang="en"):
         lines = output.strip().splitlines()
         if lines:
             prompt = lines[0].split(":", 1)[-1].strip().lstrip("*- ")
-            prompt = re.sub(r'\*{1,3}', '', prompt).strip()
+            prompt = re.sub(r"\*{1,3}", "", prompt).strip()
 
     return prompt, lyrics
 
 
 def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_MODE) -> str:
-    """
-    Generate music using the Udio model via PiAPI.
+    """Generate music using the MusicGPT API.
 
     Writes ``lyrics.lrc`` (plain text) and ``audio.wav`` into ``out_dir`` and
     returns the path to the audio file.
@@ -67,7 +71,6 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
         # ==== MOCK MODE ====
         prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
         (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
-
         mock_wav_path = Path(__file__).parent / "mock_data" / "mock_audio.wav"
         fake_wav = out_dir / "audio.wav"
         shutil.copy(mock_wav_path, fake_wav)
@@ -77,71 +80,55 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
     (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
 
+    if not MUSICGPT_API_KEY:
+        raise RuntimeError("MUSICGPT_API_KEY not set")
+
     payload = {
-        "model": "music-u",
-        "task_type": "generate_music",
-        "input": {
-            "prompt": prompt,
-            "lyrics_type": "user",
-            "lyrics": lyrics,
-        },
-        "config": {},
+        "prompt": prompt,
+        "lyrics": lyrics,
     }
-    headers = {"X-API-Key": PIAPI_KEY}
+    headers = {
+        "Authorization": MUSICGPT_API_KEY,
+        "Content-Type": "application/json",
+    }
 
     res = requests.post(
-        "https://api.piapi.ai/api/v1/task",
+        f"{API_BASE}/MusicAI",
         json=payload,
         headers=headers,
         timeout=120,
     )
     res.raise_for_status()
-    resp_data = res.json()
-    task_id = resp_data.get("data", {}).get("task_id") or resp_data.get("task_id")
-    if not task_id:
-        raise RuntimeError("No task_id returned from Udio API")
+    data = res.json()
+    conv_id = data.get("conversion_id_1") or data.get("conversion_id")
+    if not conv_id:
+        raise RuntimeError("No conversion id returned from MusicGPT API")
 
+    # Poll for completion
     for _ in range(75):
-        stat_res = requests.get(
-            f"https://api.piapi.ai/api/v1/task/{task_id}",
+        poll = requests.get(
+            f"{API_BASE}/conversion/{conv_id}",
             headers=headers,
             timeout=60,
         )
-        stat_res.raise_for_status()
-        stat_data = stat_res.json()
-        status = stat_data.get("data", {}).get("status") or stat_data.get("status")
-        # print("📄 Udio poll status data:", stat_data)
-        if status == "completed":
-            # NEW: Check audio inside songs[]
-            songs = stat_data.get("data", {}).get("output", {}).get("songs", [])
-            for song in songs:
-                audio_url = song.get("song_path")
-                if audio_url:
-                    wav_res = requests.get(audio_url, timeout=120)
-                    wav_res.raise_for_status()
-                    audio_path = out_dir / "audio.wav"
-                    audio_path.write_bytes(wav_res.content)
-                    return str(audio_path)
-
-            # FALLBACK: Previous formats
+        poll.raise_for_status()
+        poll_data = poll.json()
+        status = poll_data.get("status") or poll_data.get("data", {}).get("status")
+        if status in {"completed", "succeeded", "success", True}:
             audio_url = (
-                stat_data.get("data", {}).get("output", {}).get("audio_url")
-                or stat_data.get("data", {}).get("outputs", [{}])[0].get("url")
-                or stat_data.get("data", {}).get("works", [{}])[0].get("resource", {}).get("resource")
-                or stat_data.get("output", {}).get("audio_url")
-                or stat_data.get("outputs", [{}])[0].get("url")
-                or stat_data.get("works", [{}])[0].get("resource", {}).get("resource")
+                poll_data.get("conversion_path")
+                or poll_data.get("audio_url")
+                or poll_data.get("data", {}).get("conversion_path")
+                or poll_data.get("data", {}).get("audio_url")
             )
-
             if audio_url:
                 wav_res = requests.get(audio_url, timeout=120)
                 wav_res.raise_for_status()
                 audio_path = out_dir / "audio.wav"
                 audio_path.write_bytes(wav_res.content)
                 return str(audio_path)
-
             raise RuntimeError("No audio URL found in completed task")
         if status in {"failed", "error"}:
-            raise RuntimeError(f"Udio task failed: {status}")
+            raise RuntimeError(f"MusicGPT task failed: {status}")
         time.sleep(5)
-    raise TimeoutError("Udio API timed out")
+    raise TimeoutError("MusicGPT API timed out")

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,7 +12,7 @@ from llm_processors import (
     ImageToTagsProcessor,
     ImageToVisualEntitiesProcessor,
 )
-from udio_module import run_inference
+from musicgpt_module import run_inference
 from serpapi_module import fetch_images_for_entity
 
 OUTPUT_ROOT = Path(__file__).parent.parent / "output"
@@ -69,14 +69,14 @@ def generate_music_from_image(
     with open(out_dir / "prompt.txt", "w", encoding="utf-8") as f:
         f.write(prompt)
 
-    # 4) Assemble assistant reply for Udio
+    # 4) Assemble assistant reply for MusicGPT
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
 
     # 5) Inference (or mock)
     try:
         audio_path = run_inference(assistant_reply, out_dir)
     except Exception as e:
-        print(f"Udio failed: {e}; using mock audio")
+        print(f"MusicGPT failed: {e}; using mock audio")
         audio_path = run_inference(assistant_reply, out_dir, use_mock=True)
     return audio_path
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -24,7 +24,7 @@ from pipeline import (
     generate_tags_from_image,
     generate_images_from_image,
 )
-from udio_module import run_inference
+from musicgpt_module import run_inference
 
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- replace Udio-based music generation with MusicGPT
- add MusicGPT API key to config and update pipeline, server, and processors
- refresh README to document MusicGPT usage and new environment variable

## Testing
- `python -m pytest`
- `python -m py_compile backend/musicgpt_module.py backend/pipeline.py backend/server.py backend/llm_processors.py backend/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b25f4895408321b7d4d9dfc6523c5b