### PR TITLE
Replace Udio with Ace Step for audio generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ## Features
-- **Image → Music** via Udio (PiAPI) and GPT-4.1-mini lyrics
+- **Image → Music** via Ace Step (PiAPI) and GPT-4.1-mini lyrics
 - **Optional audio upload analyzed with Music AI for key & chord progression**
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
@@ -14,7 +14,7 @@
 - `/regenerate` re-runs music synthesis with your own prompt and lyrics
 - Toggle `TEST_MODE` (via environment variable or in `backend/config.py`) for offline demos.
   When enabled, the backend uses bundled mock data and avoids contacting the
-  GPT-4.1-mini and Udio (PiAPI) services, suitable for memory-constrained deployments.
+  GPT-4.1-mini and Ace Step (PiAPI) services, suitable for memory-constrained deployments.
 
 ---
 
@@ -26,7 +26,7 @@ omniwizz/
 │   ├── llm_module.py        ← optional Qwen2.5-VL helper
 │   ├── llm_processors.py    ← OpenAI-based processors
 │   ├── serpapi_module.py    ← related image search via SerpAPI
-│   ├── udio_module.py       ← generate music with Udio
+│   ├── ace_step_module.py   ← generate music with Ace Step
 │   ├── pipeline.py          ← core logic: routes inputs through modules
 │   └── server.py            ← FastAPI endpoints (`/generate`, `/regenerate`)
 │
@@ -55,7 +55,7 @@ omniwizz/
   The backend uses
   `python-dotenv` (included in `requirements.txt`) to load variables from a
   `.env` file if present. Set `TEST_MODE=false` in the environment to enable real API calls. When disabled,
-   the backend submits lyrics and prompts to the PiAPI Udio service via
+   the backend submits lyrics and prompts to the PiAPI Ace Step service via
    `POST https://api.piapi.ai/api/v1/task` and polls `GET /api/v1/task/{task_id}`
    until completion.
 
@@ -92,7 +92,7 @@ omniwizz/
 4. Visit `https://<username>.github.io/<repository-name>/` to access OmniWizz.
 
 
-For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and Udio (PiAPI) services so the API and frontend can run without external dependencies.
+For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and Ace Step (PiAPI) services so the API and frontend can run without external dependencies.
 
 ---
 

--- a/backend/ace_step_module.py
+++ b/backend/ace_step_module.py
@@ -1,14 +1,19 @@
 import re
 import shutil
 import time
+import base64
 import requests
 from pathlib import Path
 from config import TEST_MODE, PIAPI_KEY
 
 def extract_prompt_and_lyrics(output, lang="en"):
-    """Return (prompt, lyrics) parsed from raw model output."""
+    """Return (style_prompt, lyrics) parsed from raw model output."""
     if lang == "en":
         p_pats = [
+            r"\*\*Style Prompt:\*\*\s*(.*?)(?:\n{2,}|\*\*Lyrics)",
+            r"\*\*Style Prompt\*\*[:：]?\s*(.*?)(?:\n{2,}|\*\*Lyrics)",
+            r"Style Prompt[:：]?\s*(.*?)(?:\n{2,}|Lyrics)",
+            # Fallback to older wording
             r"\*\*Music(?:al)? Prompt:\*\*\s*(.*?)(?:\n{2,}|\*\*Lyrics)",
             r"\*\*Music(?:al)? Prompt\*\*[:：]?\s*(.*?)(?:\n{2,}|\*\*Lyrics)",
             r"Music(?:al)? Prompt[:：]?\s*(.*?)(?:\n{2,}|Lyrics)",
@@ -32,62 +37,74 @@ def extract_prompt_and_lyrics(output, lang="en"):
     prompt = ""
     lyrics = ""
 
-    # Try to extract the prompt
     for pat in p_pats:
         m = re.search(pat, output, re.IGNORECASE | re.DOTALL)
         if m:
-            prompt = re.sub(r'\*{1,3}', '', m.group(1)).strip()
+            prompt = re.sub(r"\*{1,3}", "", m.group(1)).strip()
             break
 
-    # Try to extract the lyrics
     for pat in l_pats:
         m = re.search(pat, output, re.IGNORECASE | re.DOTALL)
         if m:
             lyrics = m.group(1).strip()
             break
 
-    # Fallback: use the first line if prompt patterns failed
     if not prompt:
         lines = output.strip().splitlines()
         if lines:
             prompt = lines[0].split(":", 1)[-1].strip().lstrip("*- ")
-            prompt = re.sub(r'\*{1,3}', '', prompt).strip()
+            prompt = re.sub(r"\*{1,3}", "", prompt).strip()
 
     return prompt, lyrics
 
 
-def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_MODE) -> str:
+def run_inference(
+    assistant_reply: str,
+    out_dir: Path,
+    *,
+    audio_path: str | None = None,
+    use_mock: bool = TEST_MODE,
+) -> str:
     """
-    Generate music using the Udio model via PiAPI.
+    Generate music using the Ace Step model via PiAPI.
 
     Writes ``lyrics.lrc`` (plain text) and ``audio.wav`` into ``out_dir`` and
     returns the path to the audio file.
     """
-    if use_mock:
-        # ==== MOCK MODE ====
-        prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
-        (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+    prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
+    (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
 
+    if use_mock:
         mock_wav_path = Path(__file__).parent / "mock_data" / "mock_audio.wav"
         fake_wav = out_dir / "audio.wav"
         shutil.copy(mock_wav_path, fake_wav)
         return str(fake_wav)
 
-    # ==== REAL MODE ====
-    prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
-    (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+    headers = {"X-API-Key": PIAPI_KEY}
+
+    if audio_path:
+        with open(audio_path, "rb") as f:
+            b64_audio = base64.b64encode(f.read()).decode()
+        task_type = "audio2audio"
+        input_payload = {
+            "style_audio": b64_audio,
+            "style_prompt": prompt,
+            "lyrics": lyrics or "[inst]",
+        }
+    else:
+        task_type = "txt2audio"
+        input_payload = {
+            "style_prompt": prompt,
+            "lyrics": lyrics or "[inst]",
+            "duration": 30,
+        }
 
     payload = {
-        "model": "music-u",
-        "task_type": "generate_music",
-        "input": {
-            "prompt": prompt,
-            "lyrics_type": "user",
-            "lyrics": lyrics,
-        },
+        "model": "Qubico/ace-step",
+        "task_type": task_type,
+        "input": input_payload,
         "config": {},
     }
-    headers = {"X-API-Key": PIAPI_KEY}
 
     res = requests.post(
         "https://api.piapi.ai/api/v1/task",
@@ -99,7 +116,7 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     resp_data = res.json()
     task_id = resp_data.get("data", {}).get("task_id") or resp_data.get("task_id")
     if not task_id:
-        raise RuntimeError("No task_id returned from Udio API")
+        raise RuntimeError("No task_id returned from Ace Step API")
 
     for _ in range(75):
         stat_res = requests.get(
@@ -110,38 +127,19 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
         stat_res.raise_for_status()
         stat_data = stat_res.json()
         status = stat_data.get("data", {}).get("status") or stat_data.get("status")
-        # print("📄 Udio poll status data:", stat_data)
         if status == "completed":
-            # NEW: Check audio inside songs[]
-            songs = stat_data.get("data", {}).get("output", {}).get("songs", [])
-            for song in songs:
-                audio_url = song.get("song_path")
-                if audio_url:
-                    wav_res = requests.get(audio_url, timeout=120)
-                    wav_res.raise_for_status()
-                    audio_path = out_dir / "audio.wav"
-                    audio_path.write_bytes(wav_res.content)
-                    return str(audio_path)
-
-            # FALLBACK: Previous formats
             audio_url = (
                 stat_data.get("data", {}).get("output", {}).get("audio_url")
-                or stat_data.get("data", {}).get("outputs", [{}])[0].get("url")
-                or stat_data.get("data", {}).get("works", [{}])[0].get("resource", {}).get("resource")
                 or stat_data.get("output", {}).get("audio_url")
-                or stat_data.get("outputs", [{}])[0].get("url")
-                or stat_data.get("works", [{}])[0].get("resource", {}).get("resource")
             )
-
             if audio_url:
                 wav_res = requests.get(audio_url, timeout=120)
                 wav_res.raise_for_status()
-                audio_path = out_dir / "audio.wav"
-                audio_path.write_bytes(wav_res.content)
-                return str(audio_path)
-
+                audio_path_out = out_dir / "audio.wav"
+                audio_path_out.write_bytes(wav_res.content)
+                return str(audio_path_out)
             raise RuntimeError("No audio URL found in completed task")
         if status in {"failed", "error"}:
-            raise RuntimeError(f"Udio task failed: {status}")
+            raise RuntimeError(f"Ace Step task failed: {status}")
         time.sleep(5)
-    raise TimeoutError("Udio API timed out")
+    raise TimeoutError("Ace Step API timed out")

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,7 @@ print("🚦 TEST_MODE =", TEST_MODE)
 
 # API keys for hosted services used when TEST_MODE is disabled
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-mini
-PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Udio cloud inference
+PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Ace Step cloud inference
 SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")      # SerpAPI for image search
 MUSIC_AI_API_KEY = os.getenv("MUSIC_AI_API_KEY", "")    # Music AI chord transcription
 MUSICAI_CHORD_WORKFLOW = os.getenv("MUSICAI_CHORD_WORKFLOW", "untitled-workflow-1fe2713")

--- a/backend/llm_module.py
+++ b/backend/llm_module.py
@@ -57,7 +57,7 @@ class LLMProcessor:
                      "Here is an example of how to describe an image musically and generate lyrics. "
                      "The lyrics should be timestamped in the format [MM:SS.xx], and the timestamps should be chosen "
                      "to match the pacing and emotion of the scene.\n\n"
-                     "**Music Prompt:**\nEpic fantasy orchestra, slow build-up, thunderstorm ambience, Celtic flute melody\n\n"
+                     "**Style Prompt:**\nEpic fantasy orchestra, slow build-up, thunderstorm ambience, Celtic flute melody\n\n"
                      "**Lyrics:**\n"
                      "Your shadow dances on the dashboard shrine\n"
                      "Neon ghosts in gasoline rain\n"
@@ -68,7 +68,7 @@ class LLMProcessor:
                      "Follow the same format as the example."},
                     {"type": "image", "image": self.image_path},
                     {"type": "text", "text":
-                     "Start with the **Music Prompt**, then write **Lyrics**. "
+                     "Start with the **Style Prompt**, then write **Lyrics**. "
                      "Ensure the lyrics are at least 12 lines long, written only in English, and maintain a consistent emotional tone."}
                 ],
             }]

--- a/backend/llm_processors.py
+++ b/backend/llm_processors.py
@@ -1,7 +1,7 @@
 import requests
 import re
 import ast
-from udio_module import extract_prompt_and_lyrics
+from ace_step_module import extract_prompt_and_lyrics
 from config import TEST_MODE, OPENAI_API_KEY
 import base64
 import mimetypes
@@ -100,7 +100,7 @@ class ImageToLyricsProcessor(BaseLLMProcessor):
 
     def _mock_generate(self):
         return (
-            "**Music Prompt:** Calm piano, soft ambient pads, morning breeze, light percussion\n\n"
+            "**Style Prompt:** Calm piano, soft ambient pads, morning breeze, light percussion\n\n"
             "**Lyrics:**\n"
             "Waves gently touch the shore\n"
             "Sunrise colors fill the air\n"
@@ -125,13 +125,13 @@ class ImageToLyricsProcessor(BaseLLMProcessor):
                     "Use this progression as musical inspiration when constructing the prompt and lyrics.\n\n"
                 )
                 example_prompt = (
-                    "**Music Prompt:**\nHaunting folk ballad with fingerpicked acoustic guitar, soft pads, and a melancholic violin. "
+                    "**Style Prompt:**\nHaunting folk ballad with fingerpicked acoustic guitar, soft pads, and a melancholic violin. "
                     "Chord progression: Em - C - G - Em\n\n"
                 )
             else:
                 chord_text = ""
                 example_prompt = (
-                    "**Music Prompt:**\nEpic fantasy orchestra, slow build-up, thunderstorm ambience, Celtic flute melody\n\n"
+                    "**Style Prompt:**\nEpic fantasy orchestra, slow build-up, thunderstorm ambience, Celtic flute melody\n\n"
                 )
 
             prompt = (
@@ -144,7 +144,7 @@ class ImageToLyricsProcessor(BaseLLMProcessor):
                 "Now, based on the following image, generate a new musical prompt and a complete set of lyrics in English only. "
                 "The output must include at least 12 lines of lyrics written entirely in English. "
                 "Follow the same format as the example, but no timestamps are needed.\n\n"
-                f"{chord_text}Start with the **Music Prompt**, then write **Lyrics**. "
+                f"{chord_text}Start with the **Style Prompt**, then write **Lyrics**. "
                 "Ensure the lyrics are at least 12 lines long and maintain a consistent emotional tone."
             )
         else:

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,7 +12,7 @@ from llm_processors import (
     ImageToTagsProcessor,
     ImageToVisualEntitiesProcessor,
 )
-from udio_module import run_inference
+from ace_step_module import run_inference
 from serpapi_module import fetch_images_for_entity
 
 OUTPUT_ROOT = Path(__file__).parent.parent / "output"
@@ -69,16 +69,18 @@ def generate_music_from_image(
     with open(out_dir / "prompt.txt", "w", encoding="utf-8") as f:
         f.write(prompt)
 
-    # 4) Assemble assistant reply for Udio
-    assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
+    # 4) Assemble assistant reply for Ace Step
+    assistant_reply = f"**Style Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
 
     # 5) Inference (or mock)
     try:
-        audio_path = run_inference(assistant_reply, out_dir)
+        generated_audio = run_inference(assistant_reply, out_dir, audio_path=audio_path)
     except Exception as e:
-        print(f"Udio failed: {e}; using mock audio")
-        audio_path = run_inference(assistant_reply, out_dir, use_mock=True)
-    return audio_path
+        print(f"Ace Step failed: {e}; using mock audio")
+        generated_audio = run_inference(
+            assistant_reply, out_dir, audio_path=audio_path, use_mock=True
+        )
+    return generated_audio
 
 
 def generate_tags_from_image(

--- a/backend/server.py
+++ b/backend/server.py
@@ -24,7 +24,7 @@ from pipeline import (
     generate_tags_from_image,
     generate_images_from_image,
 )
-from udio_module import run_inference
+from ace_step_module import run_inference
 
 import os
 from dotenv import load_dotenv
@@ -189,8 +189,8 @@ async def regenerate(
     if lrc_fp.exists():
         lrc_fp.unlink()
     
-    assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
-    background_tasks.add_task(run_inference, assistant_reply, out_dir)
+    assistant_reply = f"**Style Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
+    background_tasks.add_task(run_inference, assistant_reply, out_dir, audio_path=None)
 
     log_event(
         db,


### PR DESCRIPTION
## Summary
- switch music generation backend from Udio to Ace Step
- update GPT prompts and extraction to use “Style Prompt” wording
- allow audio uploads to drive Ace Step audio2audio while keeping full audio for style

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b26e274f508321b10084ef0a41120e