### PR TITLE
feat: switch music generation from Udio to Ace Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ## Features
-- **Image → Music** via Ace Step (PiAPI) and GPT-4.1-mini lyrics
+- **Image → Music** via Ace Step (PiAPI) and GPT-4.1-mini lyrics, retrying once before falling back to bundled audio
 - **Optional audio upload analyzed with Music AI for key & chord progression**
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ## Features
-- **Image → Music** via Udio (PiAPI) and GPT-4.1-mini lyrics
+- **Image → Music** via Ace Step (PiAPI) and GPT-4.1-mini lyrics
 - **Optional audio upload analyzed with Music AI for key & chord progression**
 - **Image → Tags** for creativity prompts
 - **Image → Related Images** via SerpAPI (`SERPAPI_API_KEY` required)
@@ -14,7 +14,7 @@
 - `/regenerate` re-runs music synthesis with your own prompt and lyrics
 - Toggle `TEST_MODE` (via environment variable or in `backend/config.py`) for offline demos.
   When enabled, the backend uses bundled mock data and avoids contacting the
-  GPT-4.1-mini and Udio (PiAPI) services, suitable for memory-constrained deployments.
+  GPT-4.1-mini and Ace Step (PiAPI) services, suitable for memory-constrained deployments.
 
 ---
 
@@ -26,7 +26,7 @@ omniwizz/
 │   ├── llm_module.py        ← optional Qwen2.5-VL helper
 │   ├── llm_processors.py    ← OpenAI-based processors
 │   ├── serpapi_module.py    ← related image search via SerpAPI
-│   ├── udio_module.py       ← generate music with Udio
+│   ├── ace_step_module.py   ← generate music with Ace Step
 │   ├── pipeline.py          ← core logic: routes inputs through modules
 │   └── server.py            ← FastAPI endpoints (`/generate`, `/regenerate`)
 │
@@ -55,7 +55,7 @@ omniwizz/
   The backend uses
   `python-dotenv` (included in `requirements.txt`) to load variables from a
   `.env` file if present. Set `TEST_MODE=false` in the environment to enable real API calls. When disabled,
-   the backend submits lyrics and prompts to the PiAPI Udio service via
+   the backend submits lyrics and prompts to the PiAPI Ace Step service via
    `POST https://api.piapi.ai/api/v1/task` and polls `GET /api/v1/task/{task_id}`
    until completion.
 
@@ -92,7 +92,7 @@ omniwizz/
 4. Visit `https://<username>.github.io/<repository-name>/` to access OmniWizz.
 
 
-For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and Udio (PiAPI) services so the API and frontend can run without external dependencies.
+For offline demos or memory-constrained deployments, enable `TEST_MODE` either in `backend/config.py` or via an environment variable. This skips calling the remote GPT-4.1-mini and Ace Step (PiAPI) services so the API and frontend can run without external dependencies.
 
 ---
 

--- a/backend/ace_step_module.py
+++ b/backend/ace_step_module.py
@@ -73,6 +73,7 @@ def run_inference(
     style_audio_path: str | None = None,
     *,
     use_mock: bool = TEST_MODE,
+    retries: int = 1,
 ) -> str:
     """
     Generate music using the Ace Step model via PiAPI.
@@ -80,72 +81,81 @@ def run_inference(
     Writes ``lyrics.lrc`` (plain text) and ``audio.wav`` into ``out_dir`` and
     returns the path to the audio file.
     """
-    if use_mock:
-        # ==== MOCK MODE ====
-        prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
-        (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+    prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
+    (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
 
+    if use_mock:
         mock_wav_path = Path(__file__).parent / "mock_data" / "mock_audio.wav"
         fake_wav = out_dir / "audio.wav"
         shutil.copy(mock_wav_path, fake_wav)
         return str(fake_wav)
 
-    # ==== REAL MODE ====
-    prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
-    (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
+    attempt = 0
+    while attempt <= retries:
+        try:
+            input_payload = {
+                "style_prompt": prompt,
+                "lyrics": lyrics if lyrics.strip() else "[inst]",
+                "duration": 30,
+                "negative_style_prompt": "",
+            }
+            if style_audio_path:
+                input_payload["style_audio"] = _to_data_url(style_audio_path)
 
-    input_payload = {
-        "style_prompt": prompt,
-        "lyrics": lyrics if lyrics.strip() else "[inst]",
-        "duration": 30,
-        "negative_style_prompt": "",
-    }
-    if style_audio_path:
-        input_payload["style_audio"] = _to_data_url(style_audio_path)
+            payload = {
+                "model": "Qubico/ace-step",
+                "task_type": "txt2audio",
+                "input": input_payload,
+                "config": {},
+            }
+            headers = {"X-API-Key": PIAPI_KEY}
 
-    payload = {
-        "model": "Qubico/ace-step",
-        "task_type": "txt2audio",
-        "input": input_payload,
-        "config": {},
-    }
-    headers = {"X-API-Key": PIAPI_KEY}
-
-    res = requests.post(
-        "https://api.piapi.ai/api/v1/task",
-        json=payload,
-        headers=headers,
-        timeout=120,
-    )
-    res.raise_for_status()
-    resp_data = res.json()
-    task_id = resp_data.get("data", {}).get("task_id") or resp_data.get("task_id")
-    if not task_id:
-        raise RuntimeError("No task_id returned from Ace Step API")
-
-    for _ in range(75):
-        stat_res = requests.get(
-            f"https://api.piapi.ai/api/v1/task/{task_id}",
-            headers=headers,
-            timeout=60,
-        )
-        stat_res.raise_for_status()
-        stat_data = stat_res.json()
-        status = stat_data.get("data", {}).get("status") or stat_data.get("status")
-        if status == "completed":
-            audio_url = (
-                stat_data.get("data", {})
-                .get("output", {})
-                .get("audio_url")
+            res = requests.post(
+                "https://api.piapi.ai/api/v1/task",
+                json=payload,
+                headers=headers,
+                timeout=120,
             )
-            if not audio_url:
-                raise RuntimeError("No audio URL found in completed task")
-            wav_res = requests.get(audio_url, timeout=120)
-            wav_res.raise_for_status()
-            audio_path = out_dir / "audio.wav"
-            audio_path.write_bytes(wav_res.content)
-            return str(audio_path)
-        if status in {"failed", "error"}:
-            raise RuntimeError(f"Ace Step task failed: {status}")
-        time.sleep(5)
-    raise TimeoutError("Ace Step API timed out")
+            res.raise_for_status()
+            resp_data = res.json()
+            task_id = resp_data.get("data", {}).get("task_id") or resp_data.get("task_id")
+            if not task_id:
+                raise RuntimeError("No task_id returned from Ace Step API")
+
+            for _ in range(75):
+                stat_res = requests.get(
+                    f"https://api.piapi.ai/api/v1/task/{task_id}",
+                    headers=headers,
+                    timeout=60,
+                )
+                stat_res.raise_for_status()
+                stat_data = stat_res.json()
+                status = stat_data.get("data", {}).get("status") or stat_data.get("status")
+                if status == "completed":
+                    audio_url = (
+                        stat_data.get("data", {})
+                        .get("output", {})
+                        .get("audio_url")
+                    )
+                    if not audio_url:
+                        raise RuntimeError("No audio URL found in completed task")
+                    wav_res = requests.get(audio_url, timeout=120)
+                    wav_res.raise_for_status()
+                    audio_path = out_dir / "audio.wav"
+                    audio_path.write_bytes(wav_res.content)
+                    return str(audio_path)
+                if status in {"failed", "error"}:
+                    raise RuntimeError(f"Ace Step task failed: {status}")
+                time.sleep(5)
+            raise TimeoutError("Ace Step API timed out")
+        except Exception as e:
+            if attempt < retries:
+                print(f"Ace Step attempt {attempt + 1} failed: {e}; retrying...")
+                attempt += 1
+                time.sleep(1)
+            else:
+                print(f"Ace Step failed after {retries + 1} attempts: {e}; using fallback audio")
+                mock_wav_path = Path(__file__).parent / "mock_data" / "mock_audio.wav"
+                fake_wav = out_dir / "audio.wav"
+                shutil.copy(mock_wav_path, fake_wav)
+                return str(fake_wav)

--- a/backend/ace_step_module.py
+++ b/backend/ace_step_module.py
@@ -1,8 +1,11 @@
 import re
 import shutil
 import time
+import base64
+import mimetypes
 import requests
 from pathlib import Path
+
 from config import TEST_MODE, PIAPI_KEY
 
 def extract_prompt_and_lyrics(output, lang="en"):
@@ -56,9 +59,23 @@ def extract_prompt_and_lyrics(output, lang="en"):
     return prompt, lyrics
 
 
-def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_MODE) -> str:
+def _to_data_url(path: str) -> str:
+    """Encode a local audio file as a data URL."""
+    mime, _ = mimetypes.guess_type(path)
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    return f"data:{mime or 'audio/wav'};base64,{b64}"
+
+
+def run_inference(
+    assistant_reply: str,
+    out_dir: Path,
+    style_audio_path: str | None = None,
+    *,
+    use_mock: bool = TEST_MODE,
+) -> str:
     """
-    Generate music using the Udio model via PiAPI.
+    Generate music using the Ace Step model via PiAPI.
 
     Writes ``lyrics.lrc`` (plain text) and ``audio.wav`` into ``out_dir`` and
     returns the path to the audio file.
@@ -77,14 +94,19 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     prompt, lyrics = extract_prompt_and_lyrics(assistant_reply)
     (out_dir / "lyrics.lrc").write_text(lyrics, encoding="utf-8")
 
+    input_payload = {
+        "style_prompt": prompt,
+        "lyrics": lyrics if lyrics.strip() else "[inst]",
+        "duration": 30,
+        "negative_style_prompt": "",
+    }
+    if style_audio_path:
+        input_payload["style_audio"] = _to_data_url(style_audio_path)
+
     payload = {
-        "model": "music-u",
-        "task_type": "generate_music",
-        "input": {
-            "prompt": prompt,
-            "lyrics_type": "user",
-            "lyrics": lyrics,
-        },
+        "model": "Qubico/ace-step",
+        "task_type": "txt2audio",
+        "input": input_payload,
         "config": {},
     }
     headers = {"X-API-Key": PIAPI_KEY}
@@ -99,7 +121,7 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
     resp_data = res.json()
     task_id = resp_data.get("data", {}).get("task_id") or resp_data.get("task_id")
     if not task_id:
-        raise RuntimeError("No task_id returned from Udio API")
+        raise RuntimeError("No task_id returned from Ace Step API")
 
     for _ in range(75):
         stat_res = requests.get(
@@ -110,38 +132,20 @@ def run_inference(assistant_reply: str, out_dir: Path, *, use_mock: bool = TEST_
         stat_res.raise_for_status()
         stat_data = stat_res.json()
         status = stat_data.get("data", {}).get("status") or stat_data.get("status")
-        # print("📄 Udio poll status data:", stat_data)
         if status == "completed":
-            # NEW: Check audio inside songs[]
-            songs = stat_data.get("data", {}).get("output", {}).get("songs", [])
-            for song in songs:
-                audio_url = song.get("song_path")
-                if audio_url:
-                    wav_res = requests.get(audio_url, timeout=120)
-                    wav_res.raise_for_status()
-                    audio_path = out_dir / "audio.wav"
-                    audio_path.write_bytes(wav_res.content)
-                    return str(audio_path)
-
-            # FALLBACK: Previous formats
             audio_url = (
-                stat_data.get("data", {}).get("output", {}).get("audio_url")
-                or stat_data.get("data", {}).get("outputs", [{}])[0].get("url")
-                or stat_data.get("data", {}).get("works", [{}])[0].get("resource", {}).get("resource")
-                or stat_data.get("output", {}).get("audio_url")
-                or stat_data.get("outputs", [{}])[0].get("url")
-                or stat_data.get("works", [{}])[0].get("resource", {}).get("resource")
+                stat_data.get("data", {})
+                .get("output", {})
+                .get("audio_url")
             )
-
-            if audio_url:
-                wav_res = requests.get(audio_url, timeout=120)
-                wav_res.raise_for_status()
-                audio_path = out_dir / "audio.wav"
-                audio_path.write_bytes(wav_res.content)
-                return str(audio_path)
-
-            raise RuntimeError("No audio URL found in completed task")
+            if not audio_url:
+                raise RuntimeError("No audio URL found in completed task")
+            wav_res = requests.get(audio_url, timeout=120)
+            wav_res.raise_for_status()
+            audio_path = out_dir / "audio.wav"
+            audio_path.write_bytes(wav_res.content)
+            return str(audio_path)
         if status in {"failed", "error"}:
-            raise RuntimeError(f"Udio task failed: {status}")
+            raise RuntimeError(f"Ace Step task failed: {status}")
         time.sleep(5)
-    raise TimeoutError("Udio API timed out")
+    raise TimeoutError("Ace Step API timed out")

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,7 @@ print("🚦 TEST_MODE =", TEST_MODE)
 
 # API keys for hosted services used when TEST_MODE is disabled
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")        # GPT-4.1-mini
-PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Udio cloud inference
+PIAPI_KEY = os.getenv("PIAPI_KEY", "")                  # Ace Step cloud inference
 SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY", "")      # SerpAPI for image search
 MUSIC_AI_API_KEY = os.getenv("MUSIC_AI_API_KEY", "")    # Music AI chord transcription
 MUSICAI_CHORD_WORKFLOW = os.getenv("MUSICAI_CHORD_WORKFLOW", "untitled-workflow-1fe2713")

--- a/backend/llm_processors.py
+++ b/backend/llm_processors.py
@@ -1,7 +1,7 @@
 import requests
 import re
 import ast
-from udio_module import extract_prompt_and_lyrics
+from ace_step_module import extract_prompt_and_lyrics
 from config import TEST_MODE, OPENAI_API_KEY
 import base64
 import mimetypes

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -72,12 +72,9 @@ def generate_music_from_image(
     # 4) Assemble assistant reply for Ace Step
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
 
-    # 5) Inference (or mock)
-    try:
-        audio_path = run_inference(assistant_reply, out_dir, style_audio_path=str(audio_path) if audio_path else None)
-    except Exception as e:
-        print(f"Ace Step failed: {e}; using mock audio")
-        audio_path = run_inference(assistant_reply, out_dir, style_audio_path=str(audio_path) if audio_path else None, use_mock=True)
+    # 5) Inference with automatic retry inside run_inference
+    style_audio = str(audio_path) if audio_path else None
+    audio_path = run_inference(assistant_reply, out_dir, style_audio_path=style_audio)
     return audio_path
 
 

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,7 +12,7 @@ from llm_processors import (
     ImageToTagsProcessor,
     ImageToVisualEntitiesProcessor,
 )
-from udio_module import run_inference
+from ace_step_module import run_inference
 from serpapi_module import fetch_images_for_entity
 
 OUTPUT_ROOT = Path(__file__).parent.parent / "output"
@@ -69,15 +69,15 @@ def generate_music_from_image(
     with open(out_dir / "prompt.txt", "w", encoding="utf-8") as f:
         f.write(prompt)
 
-    # 4) Assemble assistant reply for Udio
+    # 4) Assemble assistant reply for Ace Step
     assistant_reply = f"**Music Prompt:** {prompt}\n\n**Lyrics:**\n{lyrics}"
 
     # 5) Inference (or mock)
     try:
-        audio_path = run_inference(assistant_reply, out_dir)
+        audio_path = run_inference(assistant_reply, out_dir, style_audio_path=str(audio_path) if audio_path else None)
     except Exception as e:
-        print(f"Udio failed: {e}; using mock audio")
-        audio_path = run_inference(assistant_reply, out_dir, use_mock=True)
+        print(f"Ace Step failed: {e}; using mock audio")
+        audio_path = run_inference(assistant_reply, out_dir, style_audio_path=str(audio_path) if audio_path else None, use_mock=True)
     return audio_path
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -24,7 +24,7 @@ from pipeline import (
     generate_tags_from_image,
     generate_images_from_image,
 )
-from udio_module import run_inference
+from ace_step_module import run_inference
 
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- use PiAPI Ace Step for music generation
- allow full-length reference audio while still trimming to 30s for chord analysis
- update documentation and config for Ace Step

## Testing
- `pytest`
- `python -m py_compile backend/ace_step_module.py backend/llm_processors.py backend/pipeline.py backend/server.py backend/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b275f0171c8321b7fb073a8d775af8