### PR TITLE
Preserve textbox layout when generating images

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,40 +84,75 @@ export default function App() {
   const [pendingPrompt, setPendingPrompt] = useState(false);
   const [pendingLyrics, setPendingLyrics] = useState(false);
 
+  const drawTextbox = (targetCtx, tb, artRect) => {
+    const style = window.getComputedStyle(tb);
+    const fontSize = parseFloat(style.fontSize);
+    const fontFamily = style.fontFamily;
+    const color = style.color;
+    const lineHeight = parseFloat(style.lineHeight) || fontSize;
+
+    const tbRect = tb.getBoundingClientRect();
+    const x = tbRect.left - artRect.left;
+    const y = tbRect.top - artRect.top;
+    const maxWidth = tbRect.width;
+
+    targetCtx.font = `${fontSize}px ${fontFamily}`;
+    targetCtx.fillStyle = color;
+    targetCtx.textBaseline = "top";
+
+    const lines = tb.innerText.replace(/\r\n/g, "\n").split("\n");
+    let cursorY = y;
+    lines.forEach(line => {
+      if (line === "") {
+        cursorY += lineHeight;
+        return;
+      }
+      let words = line.split(" ");
+      let current = "";
+      words.forEach(word => {
+        const test = current ? `${current} ${word}` : word;
+        if (targetCtx.measureText(test).width > maxWidth && current) {
+          targetCtx.fillText(current, x, cursorY);
+          cursorY += lineHeight;
+          current = word;
+        } else {
+          current = test;
+        }
+      });
+      while (targetCtx.measureText(current).width > maxWidth) {
+        let i = current.length;
+        while (i > 0 && targetCtx.measureText(current.slice(0, i)).width > maxWidth) {
+          i--;
+        }
+        targetCtx.fillText(current.slice(0, i), x, cursorY);
+        cursorY += lineHeight;
+        current = current.slice(i);
+      }
+      if (current) {
+        targetCtx.fillText(current, x, cursorY);
+        cursorY += lineHeight;
+      }
+    });
+  };
+
   const captureAndGenerate = () => {
     const art = document.querySelector(".artboard");
     const [bgCanvas, inkCanvas] = art.querySelectorAll("canvas");
-    const audioCanvas = document.querySelector(".wave-strip");
 
     const W = bgCanvas.width;
     const H = bgCanvas.height;
-    const hasWave = !!(audioCanvas && editorRef.current?.hasUserAudio?.());
 
-    const finalHeight = H;
     const off = document.createElement("canvas");
     off.width = W;
-    off.height = finalHeight;
+    off.height = H;
     const ctx = off.getContext("2d");
 
     ctx.drawImage(bgCanvas, 0, 0);
     ctx.drawImage(inkCanvas, 0, 0);
 
-    art.querySelectorAll(".textbox").forEach(tb => {
-      const style = window.getComputedStyle(tb);
-      const fontSize = style.fontSize;
-      const fontFamily = style.fontFamily;
-      const color = style.color;
+    const artRect = art.getBoundingClientRect();
 
-      const artRect = art.getBoundingClientRect();
-      const tbRect = tb.getBoundingClientRect();
-      const x = tbRect.left - artRect.left;
-      const y = tbRect.top - artRect.top + parseInt(fontSize, 10);
-
-      ctx.font = `${fontSize} ${fontFamily}`;
-      ctx.fillStyle = color;
-      ctx.textBaseline = "top";
-      ctx.fillText(tb.innerText, x, y);
-    });
+    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(ctx, tb, artRect));
 
     // waveform is not drawn in the backend image
 
@@ -130,22 +165,7 @@ export default function App() {
     displayCtx.drawImage(bgCanvas, 0, 0);
     displayCtx.drawImage(inkCanvas, 0, 0);
 
-    art.querySelectorAll(".textbox").forEach(tb => {
-      const style = window.getComputedStyle(tb);
-      const fontSize = style.fontSize;
-      const fontFamily = style.fontFamily;
-      const color = style.color;
-
-      const artRect = art.getBoundingClientRect();
-      const tbRect = tb.getBoundingClientRect();
-      const x = tbRect.left - artRect.left;
-      const y = tbRect.top - artRect.top + parseInt(fontSize, 10);
-
-      displayCtx.font = `${fontSize} ${fontFamily}`;
-      displayCtx.fillStyle = color;
-      displayCtx.textBaseline = "top";
-      displayCtx.fillText(tb.innerText, x, y);
-    });
+    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(displayCtx, tb, artRect));
 
     // Set canvas URL to display canvas (main part only)
     setCanvasUrl(displayCanvas.toDataURL("image/png"));
@@ -476,54 +496,40 @@ export default function App() {
       <div className="app-center-container">
 
         {canvasUrl && (
-          <div
-            className="canvas-frame back-button"
-            onClick={() => {
-              log("back_to_results_click");
-              const art = document.querySelector(".artboard");
-              if (art) {
-                const [bg, ink] = art.querySelectorAll("canvas");
-                if (bg && ink) {
-                  const w = bg.width, h = bg.height;
-                  const c = document.createElement("canvas");
-                  c.width = w;
-                  c.height = h;
-                  const ctx = c.getContext("2d");
+            <div
+              className="canvas-frame back-button"
+              onClick={() => {
+                log("back_to_results_click");
+                const art = document.querySelector(".artboard");
+                if (art) {
+                  const [bg, ink] = art.querySelectorAll("canvas");
+                  if (bg && ink) {
+                    const w = bg.width, h = bg.height;
+                    const c = document.createElement("canvas");
+                    c.width = w;
+                    c.height = h;
+                    const ctx = c.getContext("2d");
 
-                  ctx.drawImage(bg, 0, 0);
-                  ctx.drawImage(ink, 0, 0);
-
-                  art.querySelectorAll(".textbox").forEach(tb => {
-                    const style = window.getComputedStyle(tb);
-                    const fontSize   = style.fontSize;
-                    const fontFamily = style.fontFamily;
-                    const color      = style.color;
+                    ctx.drawImage(bg, 0, 0);
+                    ctx.drawImage(ink, 0, 0);
 
                     const artRect = art.getBoundingClientRect();
-                    const tbRect  = tb.getBoundingClientRect();
-                    const x = tbRect.left - artRect.left;
-                    const y = tbRect.top  - artRect.top + parseInt(fontSize, 10);
+                    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(ctx, tb, artRect));
 
-                    ctx.font = `${fontSize} ${fontFamily}`;
-                    ctx.fillStyle = color;
-                    ctx.textBaseline = "top";
-                    ctx.fillText(tb.innerText, x, y);
-                  });
-
-                  setCanvasUrl(c.toDataURL("image/png"));
+                    setCanvasUrl(c.toDataURL("image/png"));
+                  }
                 }
-              }
 
-              if (editorRef.current?.getSnapshot) {
-                setCanvasState(editorRef.current.getSnapshot());
-              }
-              setStage("done");
-            }}
-            style={{
-              position: "absolute",
-              top: "2rem",
-              right: "2rem",
-              width: "340px",
+                if (editorRef.current?.getSnapshot) {
+                  setCanvasState(editorRef.current.getSnapshot());
+                }
+                setStage("done");
+              }}
+              style={{
+                position: "absolute",
+                top: "2rem",
+                right: "2rem",
+                width: "340px",
               height: "240px",
               zIndex: 100
             }}


### PR DESCRIPTION
## Summary
- Ensure canvas export keeps textbox layout by wrapping text according to box width and line breaks
- Apply the layout-preserving rendering to both exported and display canvases
- Fix back-to-results preview so textbox layout is preserved even when Generate is skipped

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b7b477f32483219bd18590ffec0b5a