### PR TITLE
Fix textbox layout flattening when exiting editor without generating

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,57 @@ function withBase(path) {
   }
 }
 
+function drawTextbox(targetCtx, tb, artRect) {
+  const style = window.getComputedStyle(tb);
+  const fontSize = parseFloat(style.fontSize);
+  const fontFamily = style.fontFamily;
+  const color = style.color;
+  const lineHeight = parseFloat(style.lineHeight) || fontSize;
+
+  const tbRect = tb.getBoundingClientRect();
+  const x = tbRect.left - artRect.left;
+  const y = tbRect.top - artRect.top;
+  const maxWidth = tbRect.width;
+
+  targetCtx.font = `${fontSize}px ${fontFamily}`;
+  targetCtx.fillStyle = color;
+  targetCtx.textBaseline = "top";
+
+  const lines = tb.innerText.replace(/\r\n/g, "\n").split("\n");
+  let cursorY = y;
+  lines.forEach(line => {
+    if (line === "") {
+      cursorY += lineHeight;
+      return;
+    }
+    let words = line.split(" ");
+    let current = "";
+    words.forEach(word => {
+      const test = current ? `${current} ${word}` : word;
+      if (targetCtx.measureText(test).width > maxWidth && current) {
+        targetCtx.fillText(current, x, cursorY);
+        cursorY += lineHeight;
+        current = word;
+      } else {
+        current = test;
+      }
+    });
+    while (targetCtx.measureText(current).width > maxWidth) {
+      let i = current.length;
+      while (i > 0 && targetCtx.measureText(current.slice(0, i)).width > maxWidth) {
+        i--;
+      }
+      targetCtx.fillText(current.slice(0, i), x, cursorY);
+      cursorY += lineHeight;
+      current = current.slice(i);
+    }
+    if (current) {
+      targetCtx.fillText(current, x, cursorY);
+      cursorY += lineHeight;
+    }
+  });
+}
+
 const VERBS = [
   "Dreaming in pixels",
   "Composing wonders",
@@ -104,58 +155,7 @@ export default function App() {
 
     const artRect = art.getBoundingClientRect();
 
-    const drawTextbox = (targetCtx, tb) => {
-      const style = window.getComputedStyle(tb);
-      const fontSize = parseFloat(style.fontSize);
-      const fontFamily = style.fontFamily;
-      const color = style.color;
-      const lineHeight = parseFloat(style.lineHeight) || fontSize;
-
-      const tbRect = tb.getBoundingClientRect();
-      const x = tbRect.left - artRect.left;
-      const y = tbRect.top - artRect.top;
-      const maxWidth = tbRect.width;
-
-      targetCtx.font = `${fontSize}px ${fontFamily}`;
-      targetCtx.fillStyle = color;
-      targetCtx.textBaseline = "top";
-
-      const lines = tb.innerText.replace(/\r\n/g, "\n").split("\n");
-      let cursorY = y;
-      lines.forEach(line => {
-        if (line === "") {
-          cursorY += lineHeight;
-          return;
-        }
-        let words = line.split(" ");
-        let current = "";
-        words.forEach(word => {
-          const test = current ? `${current} ${word}` : word;
-          if (targetCtx.measureText(test).width > maxWidth && current) {
-            targetCtx.fillText(current, x, cursorY);
-            cursorY += lineHeight;
-            current = word;
-          } else {
-            current = test;
-          }
-        });
-        while (targetCtx.measureText(current).width > maxWidth) {
-          let i = current.length;
-          while (i > 0 && targetCtx.measureText(current.slice(0, i)).width > maxWidth) {
-            i--;
-          }
-          targetCtx.fillText(current.slice(0, i), x, cursorY);
-          cursorY += lineHeight;
-          current = current.slice(i);
-        }
-        if (current) {
-          targetCtx.fillText(current, x, cursorY);
-          cursorY += lineHeight;
-        }
-      });
-    };
-
-    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(ctx, tb));
+    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(ctx, tb, artRect));
 
     // waveform is not drawn in the backend image
 
@@ -168,7 +168,7 @@ export default function App() {
     displayCtx.drawImage(bgCanvas, 0, 0);
     displayCtx.drawImage(inkCanvas, 0, 0);
 
-    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(displayCtx, tb));
+    art.querySelectorAll(".textbox").forEach(tb => drawTextbox(displayCtx, tb, artRect));
 
     // Set canvas URL to display canvas (main part only)
     setCanvasUrl(displayCanvas.toDataURL("image/png"));
@@ -516,22 +516,8 @@ export default function App() {
                   ctx.drawImage(bg, 0, 0);
                   ctx.drawImage(ink, 0, 0);
 
-                  art.querySelectorAll(".textbox").forEach(tb => {
-                    const style = window.getComputedStyle(tb);
-                    const fontSize   = style.fontSize;
-                    const fontFamily = style.fontFamily;
-                    const color      = style.color;
-
-                    const artRect = art.getBoundingClientRect();
-                    const tbRect  = tb.getBoundingClientRect();
-                    const x = tbRect.left - artRect.left;
-                    const y = tbRect.top  - artRect.top + parseInt(fontSize, 10);
-
-                    ctx.font = `${fontSize} ${fontFamily}`;
-                    ctx.fillStyle = color;
-                    ctx.textBaseline = "top";
-                    ctx.fillText(tb.innerText, x, y);
-                  });
+                  const artRect = art.getBoundingClientRect();
+                  art.querySelectorAll(".textbox").forEach(tb => drawTextbox(ctx, tb, artRect));
 
                   setCanvasUrl(c.toDataURL("image/png"));
                 }


### PR DESCRIPTION
## Summary
- centralize `drawTextbox` helper for multiline text rendering
- use `drawTextbox` when saving canvas on Back action to preserve layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc088e83483218e9307837148ad31